### PR TITLE
Add subfolder support for api_domain wakatime api

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -4,7 +4,7 @@ const fetchWakatimeStats = async ({ username, api_domain, range }) => {
   try {
     const { data } = await axios.get(
       `https://${
-        api_domain ? api_domain.replace(/[^a-z-.0-9]/gi, "") : "wakatime.com"
+        api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com"
       }/api/v1/users/${username}/stats/${range || ''}?is_including_today=true`,
     );
 


### PR DESCRIPTION
As of right now an `api_domain` with a subfolder doesn't work. Some **wakapi** users that end up hosting their own server, may end up using a subfolder, instead of a subdomain, just like I did on mine.